### PR TITLE
Support for createdAt and updatedAt

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Please note the following :
   - [ ] Pagination
   - [ ] Filtering
 - Sails integration
-  - [ ] Allow the use of auto CreatedAt and UpdatedAt (see #3)
+  - [X] Allow the use of auto CreatedAt and UpdatedAt (see #3)
   - [ ] Pubsub integration
   - [ ] Provide a service to serialize as JSON API for custom endpoints
 - Repository

--- a/lib/api/blueprints/create.js
+++ b/lib/api/blueprints/create.js
@@ -23,6 +23,8 @@ module.exports = function createRecord(req, res) {
   Model.create(data)
     .exec( (err, newInstance) => {
 
+      if (err) return res.negotiate(err)
+
       var Q = Model.findOne(newInstance.id);
       Q.exec( (err, newRecord) => {
 

--- a/lib/api/blueprints/update.js
+++ b/lib/api/blueprints/update.js
@@ -28,6 +28,16 @@ module.exports = function updateOneRecord(req, res) {
   // But omit the blacklisted params (like JSONP callback param, etc.)
   var values = actionUtil.parseValues(req, Model);
 
+  /*
+   * Until its version 0.11.3, Waterline comes with a bug where autoUpdatedAt value is ignored during updates
+   * See PR for more details : https://github.com/balderdashy/waterline/pull/1360
+   * As a workaround, if autoUpdatedAt is set to a custom value, autoCreatedAt will be tuned off for the time of the request and updated time will be injected into the proper attribute in the resource after the request is made
+   */
+  var updatedAt = (Model.autoUpdatedAt !== false) ? Model.autoUpdatedAt : false;
+  if (updatedAt !== false) {
+    Model.autoUpdatedAt = false;
+  }
+
   // Find and update the targeted record.
   Model.update( pk, values ).exec((err, records) => {
 
@@ -49,6 +59,15 @@ module.exports = function updateOneRecord(req, res) {
 
     if (updatedRecord === undefined) {
       return res.notFound();
+    }
+
+    /*
+     * See explanation for this workaround where `updatedAt` is defined
+     */
+    if (updatedAt && (typeof updatedRecord.updatedAt) !== "undefined") {
+      updatedRecord[updatedAt] = updatedRecord["updatedAt"];
+      delete updatedRecord["updatedAt"];
+      Model.autoUpdatedAt = updatedAt;
     }
 
     delete updatedRecord.id;

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -42,8 +42,8 @@ module.exports = function(sails) {
 
     configure: function() {
       sails.config.blueprints.pluralize = true;
-      sails.config.models.autoCreatedAt = false;
-      sails.config.models.autoUpdatedAt = false;
+      sails.config.models.autoCreatedAt = "created-at";
+      sails.config.models.autoUpdatedAt = "updated-at";
     },
 
     routes: {

--- a/tests/dummy/api/controllers/PostController.js
+++ b/tests/dummy/api/controllers/PostController.js
@@ -1,0 +1,11 @@
+/**
+ * PostController
+ *
+ * @description :: Server-side logic for managing posts
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+module.exports = {
+	
+};
+

--- a/tests/dummy/api/models/Post.js
+++ b/tests/dummy/api/models/Post.js
@@ -1,0 +1,14 @@
+/**
+ * Post.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
+ */
+
+module.exports = {
+
+  attributes: {
+
+  }
+};
+

--- a/tests/dummy/api/models/User.js
+++ b/tests/dummy/api/models/User.js
@@ -9,6 +9,8 @@ module.exports = {
 
   attributes: {
 
-  }
-};
+  },
 
+  autoCreatedAt: false,
+  autoUpdatedAt: false
+};

--- a/tests/dummy/test/integration/controllers/PostController.test.js
+++ b/tests/dummy/test/integration/controllers/PostController.test.js
@@ -1,0 +1,83 @@
+var request = require('supertest');
+var JSONAPIValidator = require('jsonapi-validator').Validator;
+
+validateJSONapi = function(res) {
+  var validator = new JSONAPIValidator();
+
+  validator.validate(res.body);
+};
+
+updatedAtToBeCorrect = function(res) {
+
+  var updatedAt = res.body.data.attributes["updated-at"];
+  var dateAsString = new Date().toISOString();
+  var dateNoTimezone = dateAsString.substr(0, dateAsString.lastIndexOf("."));
+  var updatedAtNoTimezone = updatedAt.substr(0, updatedAt.lastIndexOf("."));;
+
+  if (updatedAtNoTimezone !== dateNoTimezone) {
+    throw new Error("UpdatedAt is not current date");
+  }
+};
+
+createdAtToBeNow = function(res) {
+
+  var createdAt = res.body.data.attributes["created-at"];
+  var dateAsString = new Date().toISOString();
+  var dateNoTimezone = dateAsString.substr(0, dateAsString.lastIndexOf("."));
+  var createdAtNoTimezone = createdAt.substr(0, createdAt.lastIndexOf("."));;
+
+  if (createdAtNoTimezone !== dateNoTimezone) {
+    throw new Error("CreatedAt is not current date");
+  }
+
+}
+
+describe('PostController', function() {
+
+  describe('POST /posts', function() {
+
+    it('Should return created post', function (done) {
+
+      var postToCreate = {
+        'data': {
+          'attributes': {
+            'title': 'Title test',
+            'content': 'Lorem Ipsum'
+          },
+          'type':'posts'
+        }
+      };
+
+      request(sails.hooks.http.app)
+        .post('/posts')
+        .send(postToCreate)
+        .expect(201)
+        .expect(validateJSONapi)
+        .expect(createdAtToBeNow)
+        .expect(updatedAtToBeCorrect)
+        .end(done)
+    });
+
+    it('Should update created post', function (done) {
+
+      var postToUpdate = {
+        'data': {
+          'attributes': {
+            'title': 'Title updated',
+            'content': 'Lorem Ipsum'
+          },
+          'type':'posts',
+          "id": "1"
+        }
+      };
+
+      request(sails.hooks.http.app)
+        .patch('/posts/1')
+        .send(postToUpdate)
+        .expect(200)
+        .expect(validateJSONapi)
+        .expect(updatedAtToBeCorrect)
+        .end(done)
+    });
+  });
+});

--- a/tests/dummy/test/integration/controllers/UserController.test.js
+++ b/tests/dummy/test/integration/controllers/UserController.test.js
@@ -87,7 +87,7 @@ describe('UserController', function() {
       };
 
       userCreated = userToCreate;
-      userCreated.data.id = 2;
+      userCreated.data.id = "2";
 
       request(sails.hooks.http.app)
         .post('/users')


### PR DESCRIPTION
Make `createdAt` and `updatedAt` JSON API compliant by renaming `created-at` and `updated-at`.
Workaround a bug in waterline which ignored `updated-at` values during updates.
Wirte tests to validate these auto generated attributes.

Fixes https://github.com/dynamiccast/sails-json-api-blueprints/issues/3