### PR TITLE
Fix #6 and let the workaround work even with waterline > 0.11.3

### DIFF
--- a/lib/api/blueprints/update.js
+++ b/lib/api/blueprints/update.js
@@ -28,16 +28,6 @@ module.exports = function updateOneRecord(req, res) {
   // But omit the blacklisted params (like JSONP callback param, etc.)
   var values = actionUtil.parseValues(req, Model);
 
-  /*
-   * Until its version 0.11.3, Waterline comes with a bug where autoUpdatedAt value is ignored during updates
-   * See PR for more details : https://github.com/balderdashy/waterline/pull/1360
-   * As a workaround, if autoUpdatedAt is set to a custom value, autoCreatedAt will be tuned off for the time of the request and updated time will be injected into the proper attribute in the resource after the request is made
-   */
-  var updatedAt = (Model.autoUpdatedAt !== false) ? Model.autoUpdatedAt : false;
-  if (updatedAt !== false) {
-    Model.autoUpdatedAt = false;
-  }
-
   // Find and update the targeted record.
   Model.update( pk, values ).exec((err, records) => {
 
@@ -62,12 +52,15 @@ module.exports = function updateOneRecord(req, res) {
     }
 
     /*
-     * See explanation for this workaround where `updatedAt` is defined
+     * Until its version 0.11.3, Waterline comes with a bug where autoUpdatedAt value is ignored during updates
+     * See PR for more details : https://github.com/balderdashy/waterline/pull/1360
+     * As a workaround, if autoUpdatedAt is set to a custom value and Model.update wrongly inserted a `updatedAt` field let's get this `updatedAt` value to inject it into the proper autoUpdatedAt value before removing the `updatedAt` attribute.
      */
-    if (updatedAt && (typeof updatedRecord.updatedAt) !== "undefined") {
-      updatedRecord[updatedAt] = updatedRecord["updatedAt"];
-      delete updatedRecord["updatedAt"];
-      Model.autoUpdatedAt = updatedAt;
+    if ((typeof Model.autoUpdatedAt) === "string") {
+      if ((typeof updatedRecord.updatedAt) !== "undefined") {
+        updatedRecord[Model.autoUpdatedAt] = updatedRecord["updatedAt"];
+        delete updatedRecord["updatedAt"];
+      }
     }
 
     delete updatedRecord.id;


### PR DESCRIPTION
Previously the workaround would not work if actual autoUpdatedAt value was updated. That is to say if the user was using water > 0.11.3

Fix #6 