### PR TITLE
Fix forcefully overriding controller action

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -15,6 +15,10 @@ var BlueprintController = {
   , populate: require('./api/blueprints/populate')
 };
 
+function strncmp(a, b, n){
+  return a.substring(0, n) == b.substring(0, n);
+}
+
 /**
  * Blueprints (Core Hook)
  *
@@ -102,8 +106,16 @@ module.exports = function(sails) {
 
     extendControllerMiddleware: function() {
       _.each(sails.middleware.controllers, function (controller) {
-        // Default was .defaults but we need to override default blueprints with json-api
-        _.assign(controller, hook.middleware);
+
+        // Originally was a call to _.defaults to override non defined controller actions.
+        // Here we want to make sure we only override sails default blueprints and not actual
+        // user defined controller action
+        // For this purpose we look at the Sails blueprints signature
+        _.each(hook.middleware, function(middleware, name) {
+          if (strncmp(controller[name]._middlewareType, "BLUEPRINT: ", "BLUEPRINT: ".length) === true) {
+            controller[name] = middleware;
+          }
+        });
       });
     },
 

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -390,7 +390,7 @@ module.exports = function(sails) {
 
       // Add _middlewareType keys to the functions, for debugging
       _.each(BlueprintController, function(fn, key) {
-        fn._middlewareType = 'BLUEPRINT: '+fn.name || key;
+        fn._middlewareType = 'JSON API BLUEPRINT: '+fn.name || key;
       });
 
       // Save reference to blueprints middleware in hook.

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -1,0 +1,18 @@
+/**
+ * CategoryController
+ *
+ * @description :: Server-side logic for managing categories
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+var createRecord = require('sails-json-api-blueprints/lib/api/blueprints/create');
+
+module.exports = {
+
+  create: function(req, res) {
+
+    req.body.data.attributes.name = req.body.data.attributes.name.trim();
+
+    return createRecord(req, res);
+  }
+};

--- a/tests/dummy/api/models/Category.js
+++ b/tests/dummy/api/models/Category.js
@@ -1,0 +1,16 @@
+/**
+ * Category.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
+ */
+
+module.exports = {
+
+  attributes: {
+    name: 'string'
+  },
+
+  autoCreatedAt: false,
+  autoUpdatedAt: false
+};

--- a/tests/dummy/package.json
+++ b/tests/dummy/package.json
@@ -4,6 +4,7 @@
   "description": "a Sails application",
   "keywords": [],
   "dependencies": {
+    "clone": "^1.0.2",
     "ejs": "2.3.4",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",

--- a/tests/dummy/test/integration/controllers/CategoryController.test.js
+++ b/tests/dummy/test/integration/controllers/CategoryController.test.js
@@ -1,0 +1,32 @@
+var clone = require('clone');
+var request = require('supertest');
+var JSONAPIValidator = require('jsonapi-validator').Validator;
+
+describe("Blueprint overriding", function() {
+
+  describe("POST /categories", function() {
+    it('Should trim name', function (done) {
+
+      var categoryToCreate = {
+        'data': {
+          'attributes': {
+            name: " foo"
+          },
+          'type':'categories'
+        }
+      };
+
+      categoryCreated = clone(categoryToCreate);
+      categoryCreated.data.id = "1";
+      categoryCreated.data.attributes.name = "foo";
+
+      request(sails.hooks.http.app)
+        .post('/categories')
+        .send(categoryToCreate)
+        .expect(201)
+        .expect(validateJSONapi)
+        .expect(categoryCreated)
+        .end(done);
+    });
+  });
+});


### PR DESCRIPTION
Fix #8 where user defined controller action was overriden by sails-json-api-blueprints.
The fix makes sure the soon to be overriden method is a sails blueprint.
#8 shown some developers might want to target blueprints methods for some reason. Let's give them a way to identify those from sails-json-api-blueprints