### PR TITLE
Inject JsonApiService to allow serialization in custom controller actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please note the following :
 - Sails integration
   - [X] Allow the use of auto CreatedAt and UpdatedAt (see #3)
   - [ ] Pubsub integration
-  - [ ] Provide a service to serialize as JSON API for custom endpoints
+  - [X] Provide a service to serialize as JSON API for custom endpoints
 - Repository
   - [X] Add tests on travis
   - [X] Provide status on the build on Github

--- a/lib/api/blueprints/create.js
+++ b/lib/api/blueprints/create.js
@@ -5,8 +5,6 @@ var util = require( 'util' ),
   actionUtil = require( './_util/actionUtil' ),
   pluralize = require('pluralize');
 
-var JsonApiService = require('../services/JsonApiService');
-
 /**
  * Create Record
  *

--- a/lib/api/blueprints/create.js
+++ b/lib/api/blueprints/create.js
@@ -33,7 +33,7 @@ module.exports = function createRecord(req, res) {
         var type = pluralize(req.options.model || req.options.controller);
 
         res.status(201);
-        return res.jsonp(JsonApiService.serialize(type, newRecord));
+        return res.json(JsonApiService.serialize(type, newRecord));
       });
     });
 };

--- a/lib/api/blueprints/create.js
+++ b/lib/api/blueprints/create.js
@@ -5,6 +5,8 @@ var util = require( 'util' ),
   actionUtil = require( './_util/actionUtil' ),
   pluralize = require('pluralize');
 
+var JsonApiService = require('../services/JsonApiService');
+
 /**
  * Create Record
  *
@@ -28,17 +30,10 @@ module.exports = function createRecord(req, res) {
       var Q = Model.findOne(newInstance.id);
       Q.exec( (err, newRecord) => {
 
-        var id = newRecord.id;
-        delete newRecord.id;
+        var type = pluralize(req.options.model || req.options.controller);
 
         res.status(201);
-        return res.json({
-          data: {
-            id: id.toString(),
-            type: pluralize(req.options.model || req.options.controller),
-            attributes: newRecord
-          }
-        });
+        return res.jsonp(JsonApiService.serialize(type, newRecord));
       });
     });
 };

--- a/lib/api/blueprints/find.js
+++ b/lib/api/blueprints/find.js
@@ -31,17 +31,8 @@ module.exports = function findRecords(req, res) {
       data: []
     };
 
-    matchingRecords.forEach((record) => {
-      var id = record.id;
-      delete record.id
+    var type = pluralize(req.options.model || req.options.controller);
 
-      data.data.push({
-        id: id.toString(),
-        type: pluralize(req.options.model || req.options.controller),
-        attributes: record
-      });
-    })
-
-    return res.ok(data);
+    return res.ok(JsonApiService.serialize(type, matchingRecords));
   });
 };

--- a/lib/api/blueprints/findone.js
+++ b/lib/api/blueprints/findone.js
@@ -30,13 +30,8 @@ module.exports = function findOneRecord(req, res) {
 
     if ( !matchingRecord ) return res.notFound( 'No record found with the specified `id`.' );
 
-    delete matchingRecord.id;
-    return res.ok({
-      data: {
-        id: pk,
-        type: pluralize(req.options.model || req.options.controller),
-        attributes: matchingRecord
-      }
-    });
+    var type = pluralize(req.options.model || req.options.controller);
+
+    return res.ok(JsonApiService.serialize(type, matchingRecord));
   });
 };

--- a/lib/api/blueprints/update.js
+++ b/lib/api/blueprints/update.js
@@ -63,14 +63,8 @@ module.exports = function updateOneRecord(req, res) {
       }
     }
 
-    delete updatedRecord.id;
-    res.status(200);
-    return res.ok({
-      data: {
-        id: pk.toString(),
-        type: pluralize(req.options.model || req.options.controller),
-        attributes: updatedRecord
-      }
-    });
+    var type = pluralize(req.options.model || req.options.controller);
+
+    return res.ok(JsonApiService.serialize(type, updatedRecord));
   });
 };

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -1,0 +1,46 @@
+const cleanObject = require('clean-object');
+const JSONAPISerializer = require('json-api-serializer');
+const Serializer = new JSONAPISerializer();
+
+function deepMap(obj, iterator) {
+  return _.transform(obj, function(result, val, key) {
+    result[key] = _.isObject(val) ?
+      deepMap(val, iterator) :
+      iterator.call(this, val, key, obj);
+  });
+}
+
+function _setIdTypeToString(object) {
+
+  if (typeof object['id'] === "number") {
+    object['id'] = object['id'].toString();
+  }
+
+  return object;
+}
+
+module.exports = {
+
+  serialize: function(modelName, data) {
+
+    Serializer.register(modelName, {
+      convertCase: 'kebab-case',
+      id: 'id'
+    });
+
+    // JSON API specifies resource IDs MUST be strings
+    // Let's convert all Sails integer index to strings
+    if (typeof data === "object") {
+      data = _setIdTypeToString(data);
+    } else if (typeof data === "array") {
+      data.forEach(function(object) {
+        object = _setIdTypeToString(object);
+      });
+    }
+
+    var returnedValue = cleanObject(Serializer.serialize(modelName, data));
+    delete returnedValue.jsonapi; // Let's ignore the version for now
+
+    return returnedValue;
+  }
+}

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -28,17 +28,22 @@ module.exports = {
       id: 'id'
     });
 
+    var dataToSerialize = null;
+
     // JSON API specifies resource IDs MUST be strings
     // Let's convert all Sails integer index to strings
-    if (typeof data === "object") {
-      data = _setIdTypeToString(data);
-    } else if (typeof data === "array") {
-      data.forEach(function(object) {
-        object = _setIdTypeToString(object);
+    if (data instanceof Array) {
+      dataToSerialize = [];
+
+      data.forEach(function(resource) {
+        var object = _setIdTypeToString(resource);
+        dataToSerialize.push(object);
       });
+    } else if (typeof data === "object") {
+      dataToSerialize = _setIdTypeToString(data);
     }
 
-    var returnedValue = cleanObject(Serializer.serialize(modelName, data));
+    var returnedValue = cleanObject(Serializer.serialize(modelName, dataToSerialize));
     delete returnedValue.jsonapi; // Let's ignore the version for now
 
     return returnedValue;

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -14,6 +14,7 @@ var BlueprintController = {
   , destroy : require('./api/blueprints/destroy')
   , populate: require('./api/blueprints/populate')
 };
+var JsonApiService = require('./api/services/JsonApiService');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -48,6 +49,8 @@ module.exports = function(sails) {
       sails.config.blueprints.pluralize = true;
       sails.config.models.autoCreatedAt = "created-at";
       sails.config.models.autoUpdatedAt = "updated-at";
+
+      sails.services.JsonApiService = JsonApiService;
     },
 
     routes: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "homepage": "https://github.com/dynamiccast/sails-json-api-blueprints#readme",
   "dependencies": {
+    "clean-object": "^1.0.2",
+    "json-api-serializer": "git+https://github.com/danivek/json-api-serializer.git",
     "lodash": "3.10.1",
     "path": "^0.12.7",
     "pluralize": "^2.0.0",

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -11,8 +11,13 @@ module.exports = {
 
   create: function(req, res) {
 
+    if (typeof JsonApiService === "undefined") {
+      throw new Error("JsonApiService is not injected");
+    }
+
     req.body.data.attributes.name = req.body.data.attributes.name.trim();
 
     return createRecord(req, res);
   }
+
 };


### PR DESCRIPTION
JsonApiService is available in every controller and allow to turn any waterline data into a JSON API valid format.
All blueprints have been updated to use this method of serialization instead of forging json by hand.
Bump module to version 0.4.0 and update README
