### PR TITLE
Override sails responses to be valid JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ As shown in [tests/dummy/api/controllers/UserController.js:24](https://github.co
   - [X] POST resource
   - [X] DELETE resource
   - [X] PATCH resource
-  - [ ] Return proper error if any
+  - [X] Return proper error if any
   - [ ] Relationships
   - [ ] Compound Document
   - [ ] Links

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ This module also injects a service available as `JsonApiService` in your control
 
 ## Serialize data
 
-As shown in [tests/dummy/api/controllers/UserController.js:14](https://github.com/dynamiccast/sails-json-api-blueprints/blob/master/tests/dummy/api/controllers/UserController.js#L14), `JsonApiService.serialize` allows to serialize any waterline data into a JSON API compliant format. Just call :
+`res.ok()` and `res.created()` will handle JSON API serialization for you. Simply call them as usual when you are done with your custom action.
+
+As shown in [tests/dummy/api/controllers/UserController.js:14](https://github.com/dynamiccast/sails-json-api-blueprints/blob/master/tests/dummy/api/controllers/UserController.js#L14), `JsonApiService.serialize` also allows to serialize any waterline data into a JSON API compliant format. Just call :
 
 ````
 JsonApiService(modelName, DataObject);

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ As shown in [tests/dummy/api/controllers/UserController.js:24](https://github.co
   - [X] Allow the use of auto CreatedAt and UpdatedAt (see #3)
   - [ ] Pubsub integration
   - [X] Provide a service to serialize as JSON API for custom endpoints
+  - [ ] Compatible with waterline data validation
 - Repository
   - [X] Add tests on travis
   - [X] Provide status on the build on Github

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install --save sails-json-api-blueprints
 Please note the following :
 - Being a set of blueprints this only works if `sails.config.blueprints.rest` is set to true (is it by default)
 - `sails.config.blueprints.pluralize` will be set to true to match the JSON API specification
+- Default responses will be overridden to respond with valid JSON API errors
 
 # Usage
 

--- a/lib/api/blueprints/create.js
+++ b/lib/api/blueprints/create.js
@@ -1,9 +1,7 @@
 /**
  * Module dependencies
  */
-var util = require( 'util' ),
-  actionUtil = require( './_util/actionUtil' ),
-  pluralize = require('pluralize');
+var actionUtil = require('./_util/actionUtil');
 
 /**
  * Create Record
@@ -23,15 +21,12 @@ module.exports = function createRecord(req, res) {
   Model.create(data)
     .exec( (err, newInstance) => {
 
-      if (err) return res.negotiate(err)
+      if (err) return res.negotiate(err);
 
       var Q = Model.findOne(newInstance.id);
       Q.exec( (err, newRecord) => {
 
-        var type = pluralize(req.options.model || req.options.controller);
-
-        res.status(201);
-        return res.json(JsonApiService.serialize(type, newRecord));
+        return res.created(newRecord);
       });
     });
 };

--- a/lib/api/blueprints/find.js
+++ b/lib/api/blueprints/find.js
@@ -1,9 +1,7 @@
 /**
  * Module dependencies
  */
-var util = require( 'util' ),
-  actionUtil = require( './_util/actionUtil' ),
-  pluralize = require('pluralize');
+var actionUtil = require('./_util/actionUtil');
 
 /**
  * Find Records
@@ -27,12 +25,6 @@ module.exports = function findRecords(req, res) {
 
     if (err) return res.serverError(err);
 
-    var data = {
-      data: []
-    };
-
-    var type = pluralize(req.options.model || req.options.controller);
-
-    return res.ok(JsonApiService.serialize(type, matchingRecords));
+    return res.ok(matchingRecords);
   });
 };

--- a/lib/api/blueprints/findone.js
+++ b/lib/api/blueprints/findone.js
@@ -1,10 +1,7 @@
 /**
  * Module dependencies
  */
-var util = require( 'util' ),
-    actionUtil = require( './_util/actionUtil' ),
-    pluralize = require('pluralize');
-
+var actionUtil = require('./_util/actionUtil');
 
 /**
  * Find One Record
@@ -30,8 +27,6 @@ module.exports = function findOneRecord(req, res) {
 
     if ( !matchingRecord ) return res.notFound( 'No record found with the specified `id`.' );
 
-    var type = pluralize(req.options.model || req.options.controller);
-
-    return res.ok(JsonApiService.serialize(type, matchingRecord));
+    return res.ok(matchingRecord);
   });
 };

--- a/lib/api/blueprints/findone.js
+++ b/lib/api/blueprints/findone.js
@@ -25,7 +25,7 @@ module.exports = function findOneRecord(req, res) {
   query.exec((err, matchingRecord) => {
     if ( err ) return res.serverError( err );
 
-    if ( !matchingRecord ) return res.notFound( 'No record found with the specified `id`.' );
+    if ( !matchingRecord ) return res.notFound('No record found with the specified id.');
 
     return res.ok(matchingRecord);
   });

--- a/lib/api/blueprints/update.js
+++ b/lib/api/blueprints/update.js
@@ -4,7 +4,6 @@
 
 var actionUtil  = require( './_util/actionUtil' );
 var util        = require( 'util' );
-var pluralize   = require('pluralize');
 
 /**
  * Update One Record
@@ -63,8 +62,6 @@ module.exports = function updateOneRecord(req, res) {
       }
     }
 
-    var type = pluralize(req.options.model || req.options.controller);
-
-    return res.ok(JsonApiService.serialize(type, updatedRecord));
+    return res.ok(updatedRecord);
   });
 };

--- a/lib/api/responses/badRequest.js
+++ b/lib/api/responses/badRequest.js
@@ -1,0 +1,43 @@
+/**
+ * 400 (Bad Request) Handler
+ *
+ * Usage:
+ * return res.badRequest();
+ * return res.badRequest(data);
+ * return res.badRequest(data, 'some/specific/badRequest/view');
+ *
+ * e.g.:
+ * ```
+ * return res.badRequest(
+ *   'Please choose a valid `password` (6-12 characters)',
+ *   'trial/signup'
+ * );
+ * ```
+ */
+
+module.exports = function badRequest(data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+
+  // Set status code
+  res.status(400);
+
+  // Log error to console
+  if (data !== undefined) {
+    sails.log.verbose('Sending 400 ("Bad Request") response: \n',data);
+  }
+  else sails.log.verbose('Sending 400 ("Bad Request") response');
+
+  return res.json({
+    'errors': [
+      {
+        status: "400",
+        title: 'Bad request',
+        detail: data
+      }
+      ]
+  });
+};

--- a/lib/api/responses/created.js
+++ b/lib/api/responses/created.js
@@ -1,0 +1,65 @@
+var pluralize = require('pluralize');
+
+/**
+ * 201 (CREATED) Response
+ *
+ * Usage:
+ * return res.created();
+ * return res.created(data);
+ * return res.created(data, 'auth/login');
+ *
+ * @param  {Object} data
+ * @param  {String|Object} options
+ *          - pass string to render specified view
+ */
+
+module.exports = function created(data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+  var type = pluralize(req.options.model || req.options.controller);
+
+  data = JsonApiService.serialize(type, data);
+
+  sails.log.silly('res.created() :: Sending 201 ("CREATED") response');
+
+  // Set status code
+  res.status(201);
+
+  // If appropriate, serve data as JSON(P)
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
+    return res.jsonx(data);
+  }
+
+  // If second argument is a string, we take that to mean it refers to a view.
+  // If it was omitted, use an empty object (`{}`)
+  options = (typeof options === 'string') ? { view: options } : options || {};
+
+  // Attempt to prettify data for views, if it's a non-error object
+  var viewData = data;
+  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
+    try {
+      viewData = require('util').inspect(data, {depth: null});
+    }
+    catch(e) {
+      viewData = undefined;
+    }
+  }
+
+  // If a view was provided in options, serve it.
+  // Otherwise try to guess an appropriate view, or if that doesn't
+  // work, just send JSON.
+  if (options.view) {
+    return res.view(options.view, { data: viewData, title: 'Created' });
+  }
+
+  // If no second argument provided, try to serve the implied view,
+  // but fall back to sending JSON(P) if no view can be inferred.
+  else return res.guessView({ data: viewData, title: 'Created' }, function couldNotGuessView () {
+    return res.jsonx(data);
+  });
+
+};

--- a/lib/api/responses/forbidden.js
+++ b/lib/api/responses/forbidden.js
@@ -1,0 +1,40 @@
+/**
+ * 403 (Forbidden) Handler
+ *
+ * Usage:
+ * return res.forbidden();
+ * return res.forbidden(err);
+ * return res.forbidden(err, 'some/specific/forbidden/view');
+ *
+ * e.g.:
+ * ```
+ * return res.forbidden('Access denied.');
+ * ```
+ */
+
+module.exports = function forbidden (data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+
+  // Set status code
+  res.status(403);
+
+  // Log error to console
+  if (data !== undefined) {
+    sails.log.verbose('Sending 403 ("Forbidden") response: \n',data);
+  }
+  else sails.log.verbose('Sending 403 ("Forbidden") response');
+
+  return res.json({
+    'errors': [
+      {
+        status: "403",
+        title: 'Forbidden'
+      }
+    ]
+  });
+
+};

--- a/lib/api/responses/forbidden.js
+++ b/lib/api/responses/forbidden.js
@@ -32,7 +32,8 @@ module.exports = function forbidden (data, options) {
     'errors': [
       {
         status: "403",
-        title: 'Forbidden'
+        title: 'Forbidden',
+        detail: data
       }
     ]
   });

--- a/lib/api/responses/notFound.js
+++ b/lib/api/responses/notFound.js
@@ -1,0 +1,45 @@
+/**
+ * 404 (Not Found) Handler
+ *
+ * Usage:
+ * return res.notFound();
+ * return res.notFound(err);
+ * return res.notFound(err, 'some/specific/notfound/view');
+ *
+ * e.g.:
+ * ```
+ * return res.notFound();
+ * ```
+ *
+ * NOTE:
+ * If a request doesn't match any explicit routes (i.e. `config/routes.js`)
+ * or route blueprints (i.e. "shadow routes", Sails will call `res.notFound()`
+ * automatically.
+ */
+
+module.exports = function notFound(data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+
+  // Set status code
+  res.status(404);
+
+  // Log error to console
+  if (data !== undefined) {
+    sails.log.verbose('Sending 404 ("Not Found") response: \n',data);
+  }
+  else sails.log.verbose('Sending 404 ("Not Found") response');
+
+  return res.json({
+    'errors': [
+      {
+        status: "404",
+        title: 'Resource not found',
+        detail: data
+      }
+      ]
+  });
+};

--- a/lib/api/responses/ok.js
+++ b/lib/api/responses/ok.js
@@ -1,0 +1,65 @@
+var pluralize = require('pluralize');
+
+/**
+ * 200 (OK) Response
+ *
+ * Usage:
+ * return res.ok();
+ * return res.ok(data);
+ * return res.ok(data, 'auth/login');
+ *
+ * @param  {Object} data
+ * @param  {String|Object} options
+ *          - pass string to render specified view
+ */
+
+module.exports = function sendOK(data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+  var type = pluralize(req.options.model || req.options.controller);
+
+  data = JsonApiService.serialize(type, data);
+
+  sails.log.silly('res.ok() :: Sending 200 ("OK") response');
+
+  // Set status code
+  res.status(200);
+
+  // If appropriate, serve data as JSON(P)
+  // If views are disabled, revert to json
+  if (req.wantsJSON || sails.config.hooks.views === false) {
+    return res.jsonx(data);
+  }
+
+  // If second argument is a string, we take that to mean it refers to a view.
+  // If it was omitted, use an empty object (`{}`)
+  options = (typeof options === 'string') ? { view: options } : options || {};
+
+  // Attempt to prettify data for views, if it's a non-error object
+  var viewData = data;
+  if (!(viewData instanceof Error) && 'object' == typeof viewData) {
+    try {
+      viewData = require('util').inspect(data, {depth: null});
+    }
+    catch(e) {
+      viewData = undefined;
+    }
+  }
+
+  // If a view was provided in options, serve it.
+  // Otherwise try to guess an appropriate view, or if that doesn't
+  // work, just send JSON.
+  if (options.view) {
+    return res.view(options.view, { data: viewData, title: 'OK' });
+  }
+
+  // If no second argument provided, try to serve the implied view,
+  // but fall back to sending JSON(P) if no view can be inferred.
+  else return res.guessView({ data: viewData, title: 'OK' }, function couldNotGuessView () {
+    return res.jsonx(data);
+  });
+
+};

--- a/lib/api/responses/serverError.js
+++ b/lib/api/responses/serverError.js
@@ -1,0 +1,41 @@
+/**
+ * 500 (Server Error) Response
+ *
+ * Usage:
+ * return res.serverError();
+ * return res.serverError(err);
+ * return res.serverError(err, 'some/specific/error/view');
+ *
+ * NOTE:
+ * If something throws in a policy or controller, or an internal
+ * error is encountered, Sails will call `res.serverError()`
+ * automatically.
+ */
+
+module.exports = function serverError (data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+
+  // Set status code
+  res.status(500);
+
+  // Log error to console
+  if (data !== undefined) {
+    sails.log.error('Sending 500 ("Server Error") response: \n',data);
+  }
+  else sails.log.error('Sending empty 500 ("Server Error") response');
+
+  return res.json({
+    'errors': [
+      {
+        status: "500",
+        title: 'Internal server error',
+        detail: data
+      }
+    ]
+  });
+
+};

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -17,6 +17,7 @@ var BlueprintController = {
 var JsonApiService = require('./api/services/JsonApiService');
 var responseOk = require('./api/responses/ok');
 var responseCreated = require('./api/responses/created');
+var responseNotFound = require('./api/responses/notFound');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -107,6 +108,7 @@ module.exports = function(sails) {
 
       sails.hooks.responses.middleware.ok = responseOk;
       sails.hooks.responses.middleware.created = responseCreated;
+      sails.hooks.responses.middleware.notFound = responseNotFound;
 
       // Load blueprint middleware and continue.
       loadMiddleware(cb);

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -18,6 +18,7 @@ var JsonApiService = require('./api/services/JsonApiService');
 var responseOk = require('./api/responses/ok');
 var responseCreated = require('./api/responses/created');
 var responseNotFound = require('./api/responses/notFound');
+var responseBadRequest = require('./api/responses/badRequest');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -109,6 +110,7 @@ module.exports = function(sails) {
       sails.hooks.responses.middleware.ok = responseOk;
       sails.hooks.responses.middleware.created = responseCreated;
       sails.hooks.responses.middleware.notFound = responseNotFound;
+      sails.hooks.responses.middleware.badRequest = responseBadRequest;
 
       // Load blueprint middleware and continue.
       loadMiddleware(cb);

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -20,6 +20,7 @@ var responseCreated = require('./api/responses/created');
 var responseNotFound = require('./api/responses/notFound');
 var responseBadRequest = require('./api/responses/badRequest');
 var responseForbidden = require('./api/responses/forbidden');
+var responseServerError = require('./api/responses/serverError');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -113,6 +114,7 @@ module.exports = function(sails) {
       sails.hooks.responses.middleware.notFound = responseNotFound;
       sails.hooks.responses.middleware.badRequest = responseBadRequest;
       sails.hooks.responses.middleware.forbidden = responseForbidden;
+      sails.hooks.responses.middleware.serverError = responseServerError;
 
       // Load blueprint middleware and continue.
       loadMiddleware(cb);

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -15,6 +15,8 @@ var BlueprintController = {
   , populate: require('./api/blueprints/populate')
 };
 var JsonApiService = require('./api/services/JsonApiService');
+var responseOk = require('./api/responses/ok');
+var responseCreated = require('./api/responses/created');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -102,6 +104,9 @@ module.exports = function(sails) {
         eventsToWaitFor.push('hook:controllers:loaded');
       }
       sails.after(eventsToWaitFor, hook.bindShadowRoutes);
+
+      sails.hooks.responses.middleware.ok = responseOk;
+      sails.hooks.responses.middleware.created = responseCreated;
 
       // Load blueprint middleware and continue.
       loadMiddleware(cb);

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -19,6 +19,7 @@ var responseOk = require('./api/responses/ok');
 var responseCreated = require('./api/responses/created');
 var responseNotFound = require('./api/responses/notFound');
 var responseBadRequest = require('./api/responses/badRequest');
+var responseForbidden = require('./api/responses/forbidden');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -111,6 +112,7 @@ module.exports = function(sails) {
       sails.hooks.responses.middleware.created = responseCreated;
       sails.hooks.responses.middleware.notFound = responseNotFound;
       sails.hooks.responses.middleware.badRequest = responseBadRequest;
+      sails.hooks.responses.middleware.forbidden = responseForbidden;
 
       // Load blueprint middleware and continue.
       loadMiddleware(cb);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -24,6 +24,10 @@ module.exports = {
       return res.badRequest();
     }
 
+    if (req.allParams()['forbidden'] === "true") {
+      return res.forbidden();
+    }
+
     return JsonApiService.findRecords(req. res);
   }
 

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -16,6 +16,15 @@ module.exports = {
     req.body.data.attributes.name = req.body.data.attributes.name.trim();
 
     return JsonApiService.createRecord(req, res);
+  },
+
+  find: function(req, res) {
+
+    if (req.allParams()['invalid'] === "true") {
+      return res.badRequest();
+    }
+
+    return JsonApiService.findRecords(req. res);
   }
 
 };

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -21,7 +21,7 @@ module.exports = {
   find: function(req, res) {
 
     if (req.allParams()['invalid'] === "true") {
-      return res.badRequest();
+      return res.badRequest("Something is rotten in the state of denmark");
     }
 
     if (req.allParams()['forbidden'] === "true") {

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -25,7 +25,7 @@ module.exports = {
     }
 
     if (req.allParams()['forbidden'] === "true") {
-      return res.forbidden();
+      return res.forbidden("You don't wanna do that");
     }
 
     if (req.allParams()['error'] === "true") {

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -28,6 +28,10 @@ module.exports = {
       return res.forbidden();
     }
 
+    if (req.allParams()['error'] === "true") {
+      return res.serverError('A super massive black hole just swallowed the server');
+    }
+
     return JsonApiService.findRecords(req. res);
   }
 

--- a/tests/dummy/api/controllers/UserController.js
+++ b/tests/dummy/api/controllers/UserController.js
@@ -18,7 +18,7 @@ module.exports = {
         'last-name':'Root'
       });
 
-      return res.ok(me);
+      return res.json(me);
     }
 
     return JsonApiService.findRecords(req, res);

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -1,0 +1,20 @@
+var request = require('supertest');
+var JSONAPIValidator = require('jsonapi-validator').Validator;
+
+validateJSONapi = function(res) {
+  var validator = new JSONAPIValidator();
+
+  validator.validate(res.body);
+}
+
+describe('Error handling', function() {
+  describe('GET /fake', function() {
+    it('Should return 404', function(done) {
+      request(sails.hooks.http.app)
+        .get('/fake')
+        .expect(404)
+        .expect(validateJSONapi)
+        .end(done);
+    });
+  });
+});

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -55,7 +55,8 @@ describe('Error handling', function() {
           'errors': [
             {
               status: "400",
-              title: 'Bad request'
+              title: 'Bad request',
+              detail: "Something is rotten in the state of denmark"
             }
           ]
         })

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -14,6 +14,14 @@ describe('Error handling', function() {
         .get('/fake')
         .expect(404)
         .expect(validateJSONapi)
+        .expect({
+          'errors': [
+            {
+              status: "404",
+              title: 'Resource not found'
+            }
+          ]
+        })
         .end(done);
     });
   });
@@ -24,6 +32,18 @@ describe('Error handling', function() {
         .get('/users/42')
         .expect(404)
         .expect(validateJSONapi)
+        .expect({
+          'errors': [
+            {
+              status: "404",
+              title: 'Resource not found',
+              detail: 'No record found with the specified id.'
+            }
+          ]
+        })
+        .end(done);
+    });
+  });
 
   describe('GET categories?invalid=true', function() {
     it('Should return 400', function(done) {

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -62,4 +62,22 @@ describe('Error handling', function() {
         .end(done);
     });
   });
+
+  describe('GET categories?forbidden=true', function() {
+    it('Should return 403', function(done) {
+      request(sails.hooks.http.app)
+        .get('/categories?forbidden=true')
+        .expect(403)
+        .expect(validateJSONapi)
+        .expect({
+          'errors': [
+            {
+              status: "403",
+              title: 'Forbidden'
+            }
+          ]
+        })
+        .end(done);
+    });
+  });
 });

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -24,6 +24,21 @@ describe('Error handling', function() {
         .get('/users/42')
         .expect(404)
         .expect(validateJSONapi)
+
+  describe('GET categories?invalid=true', function() {
+    it('Should return 400', function(done) {
+      request(sails.hooks.http.app)
+        .get('/categories?invalid=true')
+        .expect(400)
+        .expect(validateJSONapi)
+        .expect({
+          'errors': [
+            {
+              status: "400",
+              title: 'Bad request'
+            }
+          ]
+        })
         .end(done);
     });
   });

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -73,7 +73,8 @@ describe('Error handling', function() {
           'errors': [
             {
               status: "403",
-              title: 'Forbidden'
+              title: 'Forbidden',
+              detail: "You don't wanna do that"
             }
           ]
         })

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -17,4 +17,14 @@ describe('Error handling', function() {
         .end(done);
     });
   });
+
+  describe('GET /users/42', function() {
+    it('Should return 404', function(done) {
+      request(sails.hooks.http.app)
+        .get('/users/42')
+        .expect(404)
+        .expect(validateJSONapi)
+        .end(done);
+    });
+  });
 });

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -80,4 +80,23 @@ describe('Error handling', function() {
         .end(done);
     });
   });
+
+  describe('GET categories?error=true', function() {
+    it('Should return 500', function(done) {
+      request(sails.hooks.http.app)
+        .get('/categories?error=true')
+        .expect(500)
+        .expect(validateJSONapi)
+        .expect({
+          'errors': [
+            {
+              status: "500",
+              title: 'Internal server error',
+              detail: 'A super massive black hole just swallowed the server'
+            }
+          ]
+        })
+        .end(done);
+    });
+  });
 });

--- a/tests/dummy/test/integration/controllers/PostController.test.js
+++ b/tests/dummy/test/integration/controllers/PostController.test.js
@@ -58,6 +58,9 @@ describe('PostController', function() {
         .end(done)
     });
 
+  });
+
+  describe('PATH /posts', function() {
     it('Should update created post', function (done) {
 
       var postToUpdate = {


### PR DESCRIPTION
Override default responses with valid JSON API output
`res.ok` and `res.created` are responsible of serialization.
Add test to validation errors