### PR TITLE
Handle different attributes keys in JSON data and Sails model definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ As shown in [tests/dummy/api/controllers/UserController.js:24](https://github.co
 - `destroyOneRecord` DELETE /{model}
 - `updateOneRecord` PATCH /{model}/{id}
 
+## Customize models' attributes keys case
+
+While JSON API recommends multiple words variable to use a '-' as separator (http://jsonapi.org/recommendations/#naming) *sails-json-api-blueprints* remains open to `kebab-case` (the preferred), `snake_case`, `camelCase` or simply no change at all during serialization.
+
+In a `config/jsonapi.js`, add the following key to customize behavior:
+
+````
+attributesSerializedCase: 'kebab-case', // Default is undefined, a.k.a no tranformation during serialization
+````
+
+This will expect input JSON to have attributes key formatted in 'kebab-case'.
+
 # Roadmap
 
 - JSON API implementation

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ As shown in [tests/dummy/api/controllers/UserController.js:24](https://github.co
 - `destroyOneRecord` DELETE /{model}
 - `updateOneRecord` PATCH /{model}/{id}
 
-## Customize models' attributes keys case
+## Customize serialized JSON models' attributes keys case
 
 While JSON API recommends multiple words variable to use a '-' as separator (http://jsonapi.org/recommendations/#naming) *sails-json-api-blueprints* remains open to `kebab-case` (the preferred), `snake_case`, `camelCase` or simply no change at all during serialization.
 
@@ -56,7 +56,19 @@ In a `config/jsonapi.js`, add the following key to customize behavior:
 attributesSerializedCase: 'kebab-case', // Default is undefined, a.k.a no tranformation during serialization
 ````
 
-This will expect input JSON to have attributes key formatted in 'kebab-case'.
+This will output JSON with attributes keys formatted in 'kebab-case'.
+
+## Have a different sails models' attributes keys case than JSON payload
+
+Sails Model attributes keys can follow a different naming convention than the JSON payload. In this case, *sails-json-api-blueprints* should be aware of that when deserializing data.
+
+In a `config/jsonapi.js`, add the following key to customize behavior:
+
+````
+attributesDeserializedCase: 'camelCase', // Default is undefined, a.k.a no tranformation during serialization
+````
+
+This will expect sails Model attributes keys to follow the camelCase naming convention.
 
 # Roadmap
 

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -33,10 +33,21 @@ module.exports = {
   destroyOneRecord: destroyOneRecord,
   updateOneRecord: updateOneRecord,
 
+  getAttributesSerializedCaseSetting: function() {
+
+    var caseSetting = undefined;
+
+    if (sails.config.jsonapi !== undefined) {
+      caseSetting = sails.config.jsonapi.attributesSerializedCase;
+    }
+
+    return caseSetting;
+  },
+
   serialize: function(modelName, data) {
 
     Serializer.register(modelName, {
-      convertCase: 'kebab-case',
+      convertCase: this.getAttributesSerializedCaseSetting(),
       id: 'id'
     });
 

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -44,6 +44,17 @@ module.exports = {
     return caseSetting;
   },
 
+  getAttributesDeserializedCaseSetting: function() {
+
+    var caseSetting = undefined;
+
+    if (sails.config.jsonapi !== undefined) {
+      caseSetting = sails.config.jsonapi.attributesDeserializedCase;
+    }
+
+    return caseSetting;
+  },
+
   serialize: function(modelName, data) {
 
     Serializer.register(modelName, {

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -55,6 +55,47 @@ module.exports = {
     return caseSetting;
   },
 
+  deserialize: function(data) {
+
+    // Code inspired from the MIT licenced module https://github.com/danivek/json-api-serializer
+    const convertCase = function(data, convertCaseOptions) {
+      let converted;
+      if (_.isArray(data) || _.isPlainObject(data)) {
+        converted = _.transform(data, (result, value, key) => {
+          if (_.isArray(value) || _.isPlainObject(value)) {
+            result[convertCase(key, convertCaseOptions)] = convertCase(value, convertCaseOptions);
+          } else {
+            result[convertCase(key, convertCaseOptions)] = value;
+          }
+        });
+      } else {
+        switch (convertCaseOptions) {
+        case 'snake_case':
+          converted = _.snakeCase(data);
+          break;
+        case 'kebab-case':
+          converted = _.kebabCase(data);
+          break;
+        case 'camelCase':
+          converted = _.camelCase(data);
+          break;
+        default:
+          converted = data;
+          break;
+        }
+      }
+
+      return converted;
+    };
+
+    var caseSetting = this.getAttributesDeserializedCaseSetting();
+    if (caseSetting !== undefined) {
+      return convertCase(data, caseSetting);
+    }
+
+    return data;
+  },
+
   serialize: function(modelName, data) {
 
     Serializer.register(modelName, {

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -129,7 +129,12 @@ module.exports = function(sails) {
         // For this purpose we look at the Sails blueprints signature
         _.each(hook.middleware, function(middleware, name) {
           if (strncmp(controller[name]._middlewareType, "BLUEPRINT: ", "BLUEPRINT: ".length) === true) {
-            controller[name] = middleware;
+            controller[name] = function(req, res) {
+
+              req.body = JsonApiService.deserialize(req.body);
+
+              return middleware(req, res);
+            };
           }
         });
       });

--- a/tests/dummy/api/models/User.js
+++ b/tests/dummy/api/models/User.js
@@ -8,7 +8,15 @@
 module.exports = {
 
   attributes: {
-
+    email: {
+      type: 'string'
+    },
+    firstName: {
+      type: 'string'
+    },
+    lastName: {
+      type: 'string'
+    }
   },
 
   autoCreatedAt: false,

--- a/tests/dummy/api/models/User.js
+++ b/tests/dummy/api/models/User.js
@@ -9,13 +9,16 @@ module.exports = {
 
   attributes: {
     email: {
-      type: 'string'
+      type: 'string',
+      required: true
     },
     firstName: {
-      type: 'string'
+      type: 'string',
+      required: true
     },
     lastName: {
-      type: 'string'
+      type: 'string',
+      required: true
     }
   },
 

--- a/tests/dummy/config/jsonapi.js
+++ b/tests/dummy/config/jsonapi.js
@@ -26,5 +26,6 @@ module.exports.jsonapi = {
    * Default is undefined, that is to say untouched
    *
    */
-  attributesSerializedCase: 'kebab-case'
+  attributesSerializedCase: 'kebab-case', // As it should be in the JSON structure
+  attributesDeserializedCase: 'camelCase' // Ad it should be in Sails' model definitions
 };

--- a/tests/dummy/config/jsonapi.js
+++ b/tests/dummy/config/jsonapi.js
@@ -1,0 +1,30 @@
+/**
+ * JSON API Variable Configuration
+ * (sails.config.jsonapi)
+ *
+ * Configure sails-json-api-blueprints
+ *
+ * For more information on configuration, check out:
+ * https://github.com/dynamiccast/sails-json-api-blueprints/blob/master/README.md
+ */
+module.exports.jsonapi = {
+
+  /*
+   * Customize models attributes's key to allows attributes in Sails member to be in a different format than in json
+   * For example Model.firstName become attributes: { 'first-name': ...} once serialized in json
+   *
+   * JSON API RECOMMENDS a dash is used as a separator between multiple words (kebab-case)
+   * http://jsonapi.org/recommendations/#naming
+   *
+   * Ember.js expects json to be in kebab-case
+   *
+   * Possible values are:
+   * - snake_case: first_name
+   * - kebab-case: first-name
+   * - camel-case: firstName
+   *
+   * Default is undefined, that is to say untouched
+   *
+   */
+  attributesSerializedCase: 'kebab-case'
+};


### PR DESCRIPTION
While JSON API recommends multiple word variable to be separated with '-', this module must remains agnostic of the naming convention used be the user.

Add two attributes;
- sails.config.jsonapi.attributesDeserializedCase
- sails.config.jsonapi.attributesDerializedCase

To configure format for both JSON payload and Sails model.

Test app is configured to have kebab-case in JSON and camelCase in sails (Ember.js default).