### PR TITLE
Return sails validation errors as JSON API compliant object

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This will expect sails Model attributes keys to follow the camelCase naming conv
   - [X] Allow the use of auto CreatedAt and UpdatedAt (see #3)
   - [ ] Pubsub integration
   - [X] Provide a service to serialize as JSON API for custom endpoints
-  - [ ] Compatible with waterline data validation
+  - [X] Compatible with waterline data validation
 - Repository
   - [X] Add tests on travis
   - [X] Provide status on the build on Github

--- a/lib/api/responses/invalid.js
+++ b/lib/api/responses/invalid.js
@@ -36,7 +36,7 @@ module.exports = function badRequest(data, options) {
       errors.push({
         detail: error.message,
         source: {
-          pointer: "data/attributes/" + attributeName
+          pointer: "data/attributes/" + JsonApiService._convertCase(attributeName, JsonApiService.getAttributesSerializedCaseSetting())
         }
       });
     }

--- a/lib/api/responses/invalid.js
+++ b/lib/api/responses/invalid.js
@@ -1,0 +1,48 @@
+/**
+ * 400 (Bad Request) Invalid data handler
+ *
+ * Usage:
+ * return res.invalid(err);
+ *
+ * err must be returned from waterline with an error of type "E_VALIDATION"
+ */
+
+module.exports = function badRequest(data, options) {
+
+  // Get access to `req`, `res`, & `sails`
+  var req = this.req;
+  var res = this.res;
+  var sails = req._sails;
+
+  // Set status code
+  res.status(400);
+
+  // Return 500 if no error was provided
+  if (data === undefined || data.code !== "E_VALIDATION") {
+    sails.log.verbose('res.invalid was called with invalid waterline error data: \n', data);
+    return res.serverError('res.invalid was called with invalid waterline error data\n');
+  }
+
+  var errors = [];
+
+  for (var attributeName in data.invalidAttributes) {
+
+    var attributes = data.invalidAttributes[attributeName];
+
+    for (var index in attributes) {
+
+      var error = attributes[index];
+
+      errors.push({
+        detail: error.message,
+        source: {
+          pointer: "data/attributes/" + attributeName
+        }
+      });
+    }
+  }
+
+  return res.json({
+    'errors': errors
+  });
+};

--- a/lib/api/responses/negotiate.js
+++ b/lib/api/responses/negotiate.js
@@ -1,0 +1,49 @@
+/**
+ * Generic Error Handler / Classifier with validation handler
+ *
+ * Copied from https://github.com/balderdashy/sails/blob/109254834fe7202c4f630c2da9c1cbf97bf4c016/lib/hooks/responses/defaults/negotiate.js
+ *
+ * Calls the appropriate custom response for a given error,
+ * out of the bundled response modules:
+ * badRequest, forbidden, notFound, & serverError
+ *
+ * Defaults to `res.serverError`
+ *
+ * Usage:
+ * ```javascript
+ * if (err) return res.negotiate(err);
+ * ```
+ *
+ * @param {*} error(s)
+ *
+ */
+
+module.exports = function negotiate (err) {
+
+  // Get access to response object (`res`)
+  var res = this.res;
+
+  var statusCode = 500;
+  var body = err;
+
+  try {
+
+    statusCode = err.status || 500;
+
+    // Set the status
+    // (should be taken care of by res.* methods, but this sets a default just in case)
+    res.status(statusCode);
+
+  } catch (e) {}
+
+  // Respond using the appropriate custom response
+  if (statusCode === 403) return res.forbidden(body);
+  if (statusCode === 404) return res.notFound(body);
+
+  console.log(body);
+  // This check is specific to sails-json-api-blueprints
+  if (statusCode === 400 && err.code === "E_VALIDATION") return res.invalid(body);
+
+  if (statusCode >= 400 && statusCode < 500) return res.badRequest(body);
+  return res.serverError(body);
+};

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -55,42 +55,44 @@ module.exports = {
     return caseSetting;
   },
 
-  deserialize: function(data) {
+  // Code inspired from the MIT licenced module https://github.com/danivek/json-api-serializer
+  _convertCase: function(data, convertCaseOptions) {
 
-    // Code inspired from the MIT licenced module https://github.com/danivek/json-api-serializer
-    const convertCase = function(data, convertCaseOptions) {
-      let converted;
-      if (_.isArray(data) || _.isPlainObject(data)) {
-        converted = _.transform(data, (result, value, key) => {
-          if (_.isArray(value) || _.isPlainObject(value)) {
-            result[convertCase(key, convertCaseOptions)] = convertCase(value, convertCaseOptions);
-          } else {
-            result[convertCase(key, convertCaseOptions)] = value;
-          }
-        });
-      } else {
-        switch (convertCaseOptions) {
-        case 'snake_case':
-          converted = _.snakeCase(data);
-          break;
-        case 'kebab-case':
-          converted = _.kebabCase(data);
-          break;
-        case 'camelCase':
-          converted = _.camelCase(data);
-          break;
-        default:
-          converted = data;
-          break;
+    let converted;
+
+    if (_.isArray(data) || _.isPlainObject(data)) {
+      converted = _.transform(data, (result, value, key) => {
+        if (_.isArray(value) || _.isPlainObject(value)) {
+          result[this._convertCase(key, convertCaseOptions)] = this._convertCase(value, convertCaseOptions);
+        } else {
+          result[this._convertCase(key, convertCaseOptions)] = value;
         }
+      });
+    } else {
+      switch (convertCaseOptions) {
+      case 'snake_case':
+        converted = _.snakeCase(data);
+        break;
+      case 'kebab-case':
+        converted = _.kebabCase(data);
+        break;
+      case 'camelCase':
+        converted = _.camelCase(data);
+        break;
+      default:
+        converted = data;
+        break;
       }
+    }
 
-      return converted;
-    };
+    return converted;
+  },
+
+  deserialize: function(data) {
 
     var caseSetting = this.getAttributesDeserializedCaseSetting();
     if (caseSetting !== undefined) {
-      return convertCase(data, caseSetting);
+      return this._convertCase(data, caseSetting);
     }
 
     return data;

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -21,6 +21,7 @@ var responseNotFound = require('./api/responses/notFound');
 var responseBadRequest = require('./api/responses/badRequest');
 var responseForbidden = require('./api/responses/forbidden');
 var responseServerError = require('./api/responses/serverError');
+var responseNegotiate = require('./api/responses/negotiate');
 var responseInvalid = require('./api/responses/invalid');
 
 function strncmp(a, b, n){
@@ -116,7 +117,7 @@ module.exports = function(sails) {
       sails.hooks.responses.middleware.badRequest = responseBadRequest;
       sails.hooks.responses.middleware.forbidden = responseForbidden;
       sails.hooks.responses.middleware.serverError = responseServerError;
-      sails.hooks.responses.middleware.invalidJsonApi = responseInvalidJsonApi;
+      sails.hooks.responses.middleware.negotiate = responseNegotiate;
       sails.hooks.responses.middleware.invalid = responseInvalid;
 
       // Load blueprint middleware and continue.

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -21,6 +21,7 @@ var responseNotFound = require('./api/responses/notFound');
 var responseBadRequest = require('./api/responses/badRequest');
 var responseForbidden = require('./api/responses/forbidden');
 var responseServerError = require('./api/responses/serverError');
+var responseInvalid = require('./api/responses/invalid');
 
 function strncmp(a, b, n){
   return a.substring(0, n) == b.substring(0, n);
@@ -115,6 +116,8 @@ module.exports = function(sails) {
       sails.hooks.responses.middleware.badRequest = responseBadRequest;
       sails.hooks.responses.middleware.forbidden = responseForbidden;
       sails.hooks.responses.middleware.serverError = responseServerError;
+      sails.hooks.responses.middleware.invalidJsonApi = responseInvalidJsonApi;
+      sails.hooks.responses.middleware.invalid = responseInvalid;
 
       // Load blueprint middleware and continue.
       loadMiddleware(cb);

--- a/tests/dummy/api/models/User.js
+++ b/tests/dummy/api/models/User.js
@@ -10,14 +10,20 @@ module.exports = {
   attributes: {
     email: {
       type: 'string',
+      email: true,
+      unique: true,
       required: true
     },
     firstName: {
       type: 'string',
+      minLength: 2,
+      maxLength: 32,
       required: true
     },
     lastName: {
       type: 'string',
+      minLength: 3,
+      maxLength: 32,
       required: true
     }
   },

--- a/tests/dummy/test/integration/controllers/Errors.test.js
+++ b/tests/dummy/test/integration/controllers/Errors.test.js
@@ -101,4 +101,38 @@ describe('Error handling', function() {
         .end(done);
     });
   });
+
+  describe('POST /users with invalid attributes', function() {
+    it('Should return 400 with error details', function (done) {
+
+      var userToCreate = {
+        'data': {
+          'attributes': {
+            'email': 'test@jsonapi.com',
+            'first-name':'a', // This is invalid. Minimum length is 3
+            'last-name':'api'
+          },
+          'type':'users'
+        }
+      };
+
+      request(sails.hooks.http.app)
+        .post('/users')
+        .send(userToCreate)
+        .expect(400)
+        .expect(validateJSONapi)
+        .expect({
+          "errors": [
+            {
+              "detail": "\"minLength\" validation rule failed for input: 'a'\nSpecifically, it threw an error.  Details:\n undefined",
+              "source": {
+                "pointer": "data/attributes/first-name"
+              }
+            }
+          ]
+        })
+        .end(done);
+    });
+  });
+
 });


### PR DESCRIPTION
res.invalid can take a E_VALIDATION error object to turn into a valid JSON API errors array.
res.negotiate is overridden to call res.invalid if `err` object has code E_VALIDATION.