### PR TITLE
Upgrade json-api-serializer to have built-in id casting to string

### DIFF
--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -1,5 +1,4 @@
 const _ = require("lodash");
-const cleanObject = require('clean-object');
 const JSONAPISerializer = require('json-api-serializer');
 const jsonApiValidator = require('../../context-aware-jsonapi-validator/validator');
 const Serializer = new JSONAPISerializer();

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -18,15 +18,6 @@ function deepMap(obj, iterator) {
   });
 }
 
-function _setIdTypeToString(object) {
-
-  if (typeof object['id'] === "number") {
-    object['id'] = object['id'].toString();
-  }
-
-  return object;
-}
-
 module.exports = {
 
   findRecords: findRecords,
@@ -107,22 +98,7 @@ module.exports = {
       id: 'id'
     });
 
-    var dataToSerialize = null;
-
-    // JSON API specifies resource IDs MUST be strings
-    // Let's convert all Sails integer index to strings
-    if (data instanceof Array) {
-      dataToSerialize = [];
-
-      data.forEach(function(resource) {
-        var object = _setIdTypeToString(resource);
-        dataToSerialize.push(object);
-      });
-    } else if (typeof data === "object") {
-      dataToSerialize = _setIdTypeToString(data);
-    }
-
-    var returnedValue = cleanObject(Serializer.serialize(modelName, dataToSerialize));
+    var returnedValue = Serializer.serialize(modelName, data);
     delete returnedValue.jsonapi; // Let's ignore the version for now
 
     return returnedValue;

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -10,14 +10,6 @@ var createRecord = require('../blueprints/create');
 var destroyOneRecord = require('../blueprints/destroy');
 var updateOneRecord = require('../blueprints/update');
 
-function deepMap(obj, iterator) {
-  return _.transform(obj, function(result, val, key) {
-    result[key] = _.isObject(val) ?
-      deepMap(val, iterator) :
-      iterator.call(this, val, key, obj);
-  });
-}
-
 module.exports = {
 
   findRecords: findRecords,

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -4,7 +4,6 @@
 
 var _ = require('lodash');
 var util = require('util');
-var nodePath = require('path');
 var pluralize = require('pluralize');
 var BlueprintController = {
   create  : require('./api/blueprints/create')

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "homepage": "https://github.com/dynamiccast/sails-json-api-blueprints#readme",
   "dependencies": {
-    "clean-object": "^1.0.2",
     "json-api-serializer": "1.1.0",
     "jsonapi-validator": "^2.0.0",
     "lodash": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "json-api-serializer": "1.1.0",
     "jsonapi-validator": "^2.0.0",
     "lodash": "3.10.1",
-    "path": "^0.12.7",
     "pluralize": "^2.0.0",
     "util": "^0.10.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/dynamiccast/sails-json-api-blueprints#readme",
   "dependencies": {
     "clean-object": "^1.0.2",
-    "json-api-serializer": "1.0.0",
+    "json-api-serializer": "1.1.0",
     "jsonapi-validator": "^2.0.0",
     "lodash": "3.10.1",
     "path": "^0.12.7",


### PR DESCRIPTION
Since jsonapi-serializer 1.1.0, resources unique identifier are cast to string automatically.
Remove two unused dependencies, path and clean-object.