### PR TITLE
Fix patch method with prefix

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -49,6 +49,21 @@ module.exports = function(sails) {
 
   var hook;
 
+  const patchRoute = {};
+  /*
+   * Patch method does not redirect to the update blueprint by default
+   * (see https://github.com/balderdashy/sails/pull/2006 for more details)
+   * We will need to manually redirect all PATCH method to the update blueprint.
+   */
+  patchRoute['PATCH ' + sails.config.blueprints.prefix + '/:model/:id'] = function(req, res) {
+    let id = req.allParams()['id'];
+    let model = pluralize.singular(req.param('model'));
+
+    req.options.controller = model;
+    req.options.model = model;
+    BlueprintController.update(req, res);
+  };
+
   /**
    * Expose blueprint hook definition
    */
@@ -63,21 +78,7 @@ module.exports = function(sails) {
     },
 
     routes: {
-      after: {
-        /*
-         * Patch method does not redirect to the update blueprint by default
-         * (see https://github.com/balderdashy/sails/pull/2006 for more details)
-         * We will need to manually redirect all PATCH method to the update blueprint.
-         */
-        'PATCH /:model/:id': function(req, res) {
-          let id = req.allParams()['id'];
-          let model = pluralize.singular(req.param('model'));
-
-          req.options.controller = model;
-          req.options.model = model;
-          BlueprintController.update(req, res);
-        }
-      }
+      after: patchRoute
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Make default PATCH blueprint take sails.config.blueprints.prefix into account
Update version package to 0.8.0