### PR TITLE
Fix Overridden update action are never called

### DIFF
--- a/lib/hook.js
+++ b/lib/hook.js
@@ -55,13 +55,24 @@ module.exports = function(sails) {
    * (see https://github.com/balderdashy/sails/pull/2006 for more details)
    * We will need to manually redirect all PATCH method to the update blueprint.
    */
-  patchRoute['PATCH ' + sails.config.blueprints.prefix + '/:model/:id'] = function(req, res) {
+  let path = '';
+  if (sails.config.blueprints.prefix !== undefined) {
+    path = 'PATCH ' + sails.config.blueprints.prefix + '/:model/:id';
+  } else {
+    path = 'PATCH /:model/:id';
+  }
+  patchRoute[path] = function(req, res) {
     let id = req.allParams()['id'];
     let model = pluralize.singular(req.param('model'));
 
     req.options.controller = model;
     req.options.model = model;
-    BlueprintController.update(req, res);
+
+    if (sails.controllers[model].update !== undefined) {
+      return sails.controllers[model].update(req, res);
+    } else {
+      return BlueprintController.update(req, res);
+    }
   };
 
   /**

--- a/tests/dummy/api/controllers/CategoryController.js
+++ b/tests/dummy/api/controllers/CategoryController.js
@@ -33,6 +33,12 @@ module.exports = {
     }
 
     return JsonApiService.findRecords(req. res);
-  }
+  },
 
+  update: function(req, res) {
+
+    req.body.data.attributes.name = req.body.data.attributes.name.trim();
+
+    return JsonApiService.updateOneRecord(req, res);
+  }
 };

--- a/tests/dummy/test/integration/controllers/CategoryController.test.js
+++ b/tests/dummy/test/integration/controllers/CategoryController.test.js
@@ -2,6 +2,12 @@ var clone = require('clone');
 var request = require('supertest');
 var JSONAPIValidator = require('jsonapi-validator').Validator;
 
+validateJSONapi = function(res) {
+  var validator = new JSONAPIValidator();
+
+  validator.validate(res.body);
+}
+
 describe("Blueprint overriding", function() {
 
   describe("POST /categories", function() {
@@ -26,6 +32,32 @@ describe("Blueprint overriding", function() {
         .expect(201)
         .expect(validateJSONapi)
         .expect(categoryCreated)
+        .end(done);
+    });
+  });
+
+  describe('PATCH /categories/1', function() {
+    it("Should time name", function(done) {
+
+      var categoryToUpdate = {
+        'data': {
+          'attributes': {
+            name: " bar  "
+          },
+          'id': "1",
+          'type':'categories'
+        }
+      };
+
+      let categoryUpdated = clone(categoryToUpdate);
+      categoryUpdated.data.attributes.name = "bar";
+
+      request(sails.hooks.http.app)
+        .patch('/categories/1')
+        .send(categoryToUpdate)
+        .expect(200)
+        .expect(validateJSONapi)
+        .expect(categoryUpdated)
         .end(done);
     });
   });


### PR DESCRIPTION
Fixes https://github.com/dynamiccast/sails-json-api-blueprints/issues/23

Custom PATCH route used to call default blueprint without even looking for eventual custom implementation.
Add test to validate override update actions work