### PR TITLE
Use Model's primary key instead of hard coded `id`

### DIFF
--- a/lib/api/blueprints/_util/actionUtil.js
+++ b/lib/api/blueprints/_util/actionUtil.js
@@ -36,7 +36,10 @@ module.exports = {
   parseValues: function(req, model) {
 
     var values = req.body.data.attributes || {};
-    values.id = req.allParams()['id'];
+
+    if (req.allParams()['id']) {
+      values[model.primaryKey] = req.allParams()['id'];
+    }
 
     return values;
   },

--- a/lib/api/blueprints/create.js
+++ b/lib/api/blueprints/create.js
@@ -23,8 +23,12 @@ module.exports = function createRecord(req, res) {
 
       if (err) return res.negotiate(err);
 
-      var Q = Model.findOne(newInstance.id);
+      var Q = Model.findOne(newInstance[Model.primaryKey]);
       Q.exec( (err, newRecord) => {
+
+        if (err) {
+          return res.negotiate(err);
+        }
 
         return res.created(newRecord);
       });

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -1,4 +1,5 @@
 const _ = require("lodash");
+const pluralize = require('pluralize');
 const JSONAPISerializer = require('json-api-serializer');
 const jsonApiValidator = require('../../context-aware-jsonapi-validator/validator');
 const Serializer = new JSONAPISerializer();
@@ -37,6 +38,22 @@ module.exports = {
     }
 
     return caseSetting;
+  },
+
+  /*
+   * Method to get an sails Model from a model's name
+   *
+   * @method _getModelObjectFromModelName
+   * @param {string} model name
+   * @return {object} sails model
+   */
+  _getModelObjectFromModelName: function(modelName) {
+
+    modelName = _.camelCase(modelName); // Model variable name are always in one word with no seprator
+    modelName = pluralize.singular(modelName); // Model variable name are always singular
+    modelName = _.upperFirst(modelName); // Model variable name always have their first letter capitalize
+
+    return global[modelName];
   },
 
   // Code inspired from the MIT licenced module https://github.com/danivek/json-api-serializer
@@ -84,9 +101,18 @@ module.exports = {
 
   serialize: function(modelName, data) {
 
+    let Model = this._getModelObjectFromModelName(modelName);
+    let id = 'id';
+
+    if (Model) {
+      id = Model.primaryKey;
+    } else {
+      sails.log.warn('Model ' + modelName + ' could not be found by sails-json-api-blueprints');
+    }
+
     Serializer.register(modelName, {
       convertCase: this.getAttributesSerializedCaseSetting(),
-      id: 'id'
+      id: id
     });
 
     var returnedValue = Serializer.serialize(modelName, data);

--- a/tests/dummy/api/controllers/CustomController.js
+++ b/tests/dummy/api/controllers/CustomController.js
@@ -1,0 +1,11 @@
+/**
+ * CustomController
+ *
+ * @description :: Server-side logic for managing customs
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+module.exports = {
+	
+};
+

--- a/tests/dummy/api/models/Custom.js
+++ b/tests/dummy/api/models/Custom.js
@@ -1,0 +1,24 @@
+/**
+ * Custom.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
+ */
+
+module.exports = {
+
+  autoPK: false,
+
+  attributes: {
+    key: {
+      type: 'integer',
+      autoIncrement: true,
+      primaryKey: true,
+      unique: true,
+      index: true
+    }
+  },
+
+  autoCreatedAt: false,
+  autoUpdatedAt: false
+};

--- a/tests/dummy/test/integration/controllers/CustomController.test.js
+++ b/tests/dummy/test/integration/controllers/CustomController.test.js
@@ -1,0 +1,37 @@
+var clone = require('clone');
+var request = require('supertest');
+var JSONAPIValidator = require('jsonapi-validator').Validator;
+
+validateJSONapi = function(res) {
+  var validator = new JSONAPIValidator();
+
+  validator.validate(res.body);
+};
+
+describe("Custom primary key name", function() {
+
+  describe("POST /customs", function() {
+
+    it('Should return a unique identifier from custom sails primaryKey', function (done) {
+
+      var categoryToCreate = {
+        'data': {
+          'attributes': {
+          },
+          'type':'customs'
+        }
+      };
+
+      categoryCreated = clone(categoryToCreate);
+      categoryCreated.data.id = "1";
+
+      request(sails.hooks.http.app)
+        .post('/customs')
+        .send(categoryToCreate)
+        .expect(201)
+        .expect(validateJSONapi)
+        .expect(categoryCreated)
+        .end(done);
+    });
+  });
+});


### PR DESCRIPTION
Use Model.primaryKey to refer to the Model's primary key instead of hard-coded `id`.