### PR TITLE
Fix many to many relationships not mentioned both ways

### DIFF
--- a/lib/api/blueprints/_util/actionUtil.js
+++ b/lib/api/blueprints/_util/actionUtil.js
@@ -113,9 +113,27 @@ module.exports = {
    */
   updateRelationship(recordToUpdate, relationshipName, relationships) {
 
-    // First let's remove all current relationships
-    recordToUpdate[relationshipName].forEach((toDelete) => {
+    var a = recordToUpdate[relationshipName];
+    var b = relationships.data;
+
+    var toDelete = a.filter(function(current){
+      return b.filter(function(current_b){
+        return current_b.id == current.id;
+      }).length == 0;
+    });
+
+    var toAdd = b.filter(function(current){
+      return a.filter(function(current_a){
+        return current_a.id == current.id;
+      }).length == 0;
+    });
+
+    toDelete.forEach((toDelete) => {
       recordToUpdate[relationshipName].remove(toDelete.id);
+    });
+
+    toAdd.forEach((toAdd) => {
+      recordToUpdate[relationshipName].add(toAdd.id);
     });
 
     return new Promise((resolve, reject) => {
@@ -124,18 +142,8 @@ module.exports = {
           return reject(err);
         }
 
-        relationships.data.forEach((relationship) => {
-          recordToUpdate[relationshipName].add(relationship.id);
-        });
-
-        recordToUpdate.save((err) => {
-          if (err) {
-            return reject(err);
-          }
-
-          return resolve(null);
-        });
+        return resolve(null);
       });
-    })
+    });
   }
 };

--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -129,6 +129,17 @@ module.exports = {
   serialize: function(modelName, data) {
 
     var returnedValue = Serializer.serialize(modelName, data);
+
+    /*
+     * To avoid the situation where many to many relationships are not described both ways
+     * let's remove all included record's relationships
+     * See https://github.com/danivek/json-api-serializer/issues/10 for more information
+     */
+    if (returnedValue.included) {
+      returnedValue.included.forEach((include) => {
+        delete include.relationships;
+      });
+    }
     delete returnedValue.jsonapi; // Let's ignore the version for now
 
     return returnedValue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {

--- a/tests/dummy/test/integration/controllers/Relationships.test.js
+++ b/tests/dummy/test/integration/controllers/Relationships.test.js
@@ -124,11 +124,6 @@ describe("Has many through relationships", function() {
                     "id": houseId,
                     "attributes": {
                       "city": "Paris"
-                    },
-                    "relationships": {
-                      "pets": {
-                        "data": []
-                      }
                     }
                   }]
                 })


### PR DESCRIPTION
Temporary fix this issue by removing included record's relationships.
The complete issue is described here: https://github.com/danivek/json-api-serializer/issues/10

This PR also optimize the way `JsonApiService.updateRelationship` is performed by removing the extra `save`.

Bump to version 0.11.1