### PR TITLE
Support sails's model.toJSON()

### DIFF
--- a/lib/api/services/JsonApiService.js
+++ b/lib/api/services/JsonApiService.js
@@ -173,7 +173,36 @@ module.exports = {
     return data;
   },
 
+
+  /*
+   * Call toJSON recursively for all objects in data
+   *
+   * @param {Object|array} input data
+   * @return {Object|array} data with toJSON called for every included objects
+   */
+  _toJSON: function(data) {
+    // Empty data
+    if (_.isEmpty(data)) {
+      // Return [] or null
+      return _.isArray(data) ? data : null;
+    }
+
+    // Array data
+    if (_.isArray(data)) {
+      return data.map(obj => this._toJSON(obj));
+    }
+
+    // Single data
+    if (typeof data.toJSON === 'function') {
+      return data.toJSON();
+    }
+
+    return data;
+  },
+
   serialize: function(modelName, data) {
+
+    data = this._toJSON(data);
 
     var returnedValue = null;
     if ((_.isArray(data) && depthOf(data) > 2) || (_.isObjectLike(data) && _.isArray(data) === false && depthOf(data) > 1)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {

--- a/tests/dummy/api/controllers/JsonController.js
+++ b/tests/dummy/api/controllers/JsonController.js
@@ -1,0 +1,11 @@
+/**
+ * JsonController
+ *
+ * @description :: Server-side logic for managing jsons
+ * @help        :: See http://sailsjs.org/#!/documentation/concepts/Controllers
+ */
+
+module.exports = {
+	
+};
+

--- a/tests/dummy/api/models/Json.js
+++ b/tests/dummy/api/models/Json.js
@@ -1,0 +1,29 @@
+/**
+ * Json.js
+ *
+ * @description :: TODO: You might write a short summary of how this model works and what it represents here.
+ * @docs        :: http://sailsjs.org/documentation/concepts/models-and-orm/models
+ */
+
+module.exports = {
+
+  attributes: {
+    variable: {
+      type: 'string'
+    },
+    invisible: {
+      type: 'string'
+    },
+
+    toJSON: function() {
+
+      var obj = this.toObject();
+      delete obj.invisible;
+
+      return obj;
+    }
+  },
+
+  autoCreatedAt: false,
+  autoUpdatedAt: false
+};

--- a/tests/dummy/test/integration/controllers/JsonController.test.js
+++ b/tests/dummy/test/integration/controllers/JsonController.test.js
@@ -1,0 +1,40 @@
+var request = require('supertest');
+var JSONAPIValidator = require('jsonapi-validator').Validator;
+
+validateJSONapi = function(res) {
+  var validator = new JSONAPIValidator();
+
+  validator.validate(res.body);
+};
+
+describe('toJSON compatibility', function() {
+
+  it('Should return record without the hidden field', function(done) {
+
+    let toCreate = {
+      'data': {
+        'attributes': {
+          variable: "test",
+          invisible: "should not be displayed"
+        },
+        'type': 'jsons'
+      }
+    };
+
+    request(sails.hooks.http.app)
+      .post('/jsons')
+      .send(toCreate)
+      .expect(201)
+      .expect(validateJSONapi)
+      .expect({
+        data: {
+          id: '1',
+          type: 'jsons',
+          attributes: {
+            variable: 'test'
+          }
+        }
+      })
+      .end(done);
+  });
+});


### PR DESCRIPTION
Work from @leblantoine in closed PR https://github.com/dynamiccast/sails-json-api-blueprints/pull/33

Sails.js support registering a function to call prior to any serialization. This functions should be called by *fails-json-api-blueprints*