### PR TITLE
Non intrusive error handling

### DIFF
--- a/lib/api/responses/negotiate.js
+++ b/lib/api/responses/negotiate.js
@@ -20,30 +20,18 @@
 
 module.exports = function negotiate (err) {
 
-  // Get access to response object (`res`)
   var res = this.res;
+  var statusCode = err.status || 500;
 
-  var statusCode = 500;
-  var body = err;
-
-  try {
-
-    statusCode = err.status || 500;
-
-    // Set the status
-    // (should be taken care of by res.* methods, but this sets a default just in case)
-    res.status(statusCode);
-
-  } catch (e) {}
+  res.status(statusCode);
 
   // Respond using the appropriate custom response
-  if (statusCode === 403) return res.forbidden(body);
-  if (statusCode === 404) return res.notFound(body);
+  if (statusCode === 403) return res.forbidden(err);
+  if (statusCode === 404) return res.notFound(err);
 
-  console.log(body);
   // This check is specific to sails-json-api-blueprints
-  if (statusCode === 400 && err.code === "E_VALIDATION") return res.invalid(body);
+  if (statusCode === 400 && err.code === "E_VALIDATION") return res.invalid(err);
+  if (statusCode === 400) return res.badRequest(err);
 
-  if (statusCode >= 400 && statusCode < 500) return res.badRequest(body);
-  return res.serverError(body);
+  return res.json(err);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Make `res.negotiate` forward error rather than trying to interpret it.
Bump to version 0.12.0