### PR TITLE
Fix one to one relationship on update crash

### DIFF
--- a/lib/api/blueprints/update.js
+++ b/lib/api/blueprints/update.js
@@ -57,7 +57,9 @@ module.exports = function updateOneRecord(req, res) {
 
           let relationships = req.body.data.relationships[name];
 
-          actionUtil.updateRelationship(updatedRecord, name, relationships);
+          if (_.isArray(updatedRecord[name])) {
+            actionUtil.updateRelationship(updatedRecord, name, relationships);
+          }
         }
 
         updatedRecord.save((err) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
JSON API defines empty one to one relationship as being `null`.

Example: 

````
{
    "data": {
        "id": "5fccbe2f-c38e-4b6f-b664-6e01b28c0b82",
        "attributes": {
            "is-admin": false,
            "first-name": "Olivier",
            "last-name": "Berthonneau"
        },
        "relationships": {
            "team": {
                "data": null
            }
        },
        "type": "users"
    }
}
````

Would crash because `data.relationships.team.data` is not an array.