### PR TITLE
Fix deleting one way relationship did not work

### DIFF
--- a/lib/api/blueprints/update.js
+++ b/lib/api/blueprints/update.js
@@ -60,7 +60,11 @@ module.exports = function updateOneRecord(req, res) {
           if (_.isArray(updatedRecord[name])) {
             actionUtil.updateRelationship(updatedRecord, name, relationships);
           } else {
-            updatedRecord[name] = relationships.data.id;
+            if (relationships.data) {
+              updatedRecord[name] = relationships.data.id;
+            } else {
+              updatedRecord[name] = null;
+            }
           }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-json-api-blueprints",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Blueprints to turn a Sails.js API into a JSON API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The case where the client would like to remove the existing relationship was not handled and resulted in a crash.